### PR TITLE
Reduce memory alloc

### DIFF
--- a/slot_pool.go
+++ b/slot_pool.go
@@ -1,0 +1,36 @@
+package workerpool
+
+import "sync"
+
+func newSlotPool(size uint32) *SlotPool {
+	return &SlotPool{
+		lock:     &sync.RWMutex{},
+		slotChan: make(chan slot, size),
+	}
+}
+
+func (sp *SlotPool) reserve() bool {
+	sp.lock.RLock()
+	defer sp.lock.RUnlock()
+
+	if sp.isClosed {
+		return false
+	}
+
+	sp.slotChan <- slot{}
+
+	return true
+}
+
+func (sp *SlotPool) release() {
+	<-sp.slotChan
+}
+
+func (sp *SlotPool) close() {
+	sp.lock.Lock()
+	defer sp.lock.Unlock()
+
+	sp.isClosed = true
+
+	close(sp.slotChan)
+}

--- a/workerpool.go
+++ b/workerpool.go
@@ -9,14 +9,20 @@ import (
 type (
 	WorkerPool struct {
 		wg        *sync.WaitGroup
-		workers   chan worker
+		slots     *SlotPool
 		taskQueue chan Task
 		keepAlive bool
 	}
 
 	Task func()
 
-	worker struct{}
+	slot struct{}
+
+	SlotPool struct {
+		lock     *sync.RWMutex
+		isClosed bool
+		slotChan chan slot
+	}
 )
 
 const minSize = 1
@@ -36,7 +42,7 @@ func New(size uint32, opts ...Option) (*WorkerPool, error) {
 
 	workerpool := &WorkerPool{
 		wg:        &sync.WaitGroup{},
-		workers:   make(chan worker, size),
+		slots:     newSlotPool(size),
 		taskQueue: make(chan Task, poolOpts.taskQueueSize),
 		keepAlive: poolOpts.keepAlive,
 	}
@@ -53,6 +59,8 @@ func (wp *WorkerPool) Submit(task Task) {
 }
 
 func (wp *WorkerPool) Wait(ctx context.Context) error {
+	defer wp.finalize()
+
 	done := make(chan struct{}, 1)
 
 	if wp.keepAlive {
@@ -61,14 +69,12 @@ func (wp *WorkerPool) Wait(ctx context.Context) error {
 
 	go func() {
 		wp.wg.Wait()
-		wp.finalize()
 
 		done <- struct{}{}
 	}()
 
 	select {
 	case <-done:
-		return nil
 
 	case <-ctx.Done():
 		if wp.keepAlive {
@@ -76,29 +82,39 @@ func (wp *WorkerPool) Wait(ctx context.Context) error {
 		}
 
 		wp.wg.Wait()
-		wp.finalize()
 
 		return fmt.Errorf("wait exited: %w", ctx.Err())
 	}
+
+	return nil
 }
 
-// TODO: dispatch should recive a stopSignal to exit.
 func (wp *WorkerPool) dispatch() {
 	for {
-		wp.workers <- worker{} // reserve a worker for the task
+		if ok := wp.slots.reserve(); !ok {
+			return
+		}
 
-		go func() {
-			for task := range wp.taskQueue {
-				task()
-				wp.wg.Done()
-			}
-
-			<-wp.workers // release a worker
-		}()
+		go worker(wp.slots, wp.taskQueue, wp.wg)
 	}
 }
 
 func (wp *WorkerPool) finalize() {
-	// close(wp.taskQueue)
-	// close(wp.workers)
+	close(wp.taskQueue)
+	wp.slots.close()
+}
+
+func worker(slots *SlotPool, taskQueue chan Task, waitGroup *sync.WaitGroup) {
+	for {
+		task, ok := <-taskQueue
+
+		if !ok {
+			slots.release()
+
+			return
+		}
+
+		task()
+		waitGroup.Done()
+	}
 }

--- a/workerpool_benchmark_test.go
+++ b/workerpool_benchmark_test.go
@@ -15,9 +15,7 @@ func BenchmarkWorkerPool(b *testing.B) {
 	wPool, _ := workerpool.New(poolSize)
 
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 100; j++ {
-			wPool.Submit(stubFunc)
-		}
+		wPool.Submit(stubFunc)
 	}
 
 	_ = wPool.Wait(context.Background())

--- a/workerpool_benchmark_test.go
+++ b/workerpool_benchmark_test.go
@@ -1,0 +1,24 @@
+package workerpool_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zaidsasa/workerpool"
+)
+
+const poolSize = 10
+
+func stubFunc() {}
+
+func BenchmarkWorkerPool(b *testing.B) {
+	wPool, _ := workerpool.New(poolSize)
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 100; j++ {
+			wPool.Submit(stubFunc)
+		}
+	}
+
+	_ = wPool.Wait(context.Background())
+}

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -13,7 +13,7 @@ func TestNew(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		size    int
+		size    uint32
 		options []workerpool.Option
 	}
 


### PR DESCRIPTION
Before:
```
➜  workerpool git:(main) ✗ go test -bench . -benchtime=1000x -benchmem
goos: darwin
goarch: amd64
pkg: github.com/zaidsasa/workerpool
cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
BenchmarkWorkerPool-8               1000             54691 ns/op            2503 B/op        100 allocs/op
PASS
ok      github.com/zaidsasa/workerpool  2.256s
```

After: 
```
➜  workerpool git:(reduce-memory-alloc) go test -bench . -benchtime=1000x -benchmem
goos: darwin
goarch: amd64
pkg: github.com/zaidsasa/workerpool
cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
BenchmarkWorkerPool-8               1000             24676 ns/op               9 B/op          0 allocs/op
PASS
ok      github.com/zaidsasa/workerpool  2.232s
```