### PR TITLE
add benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ Please feel free to submit issues, fork the repository and send pull requests!
 ## License
 
 This project is licensed under the terms of the MIT license.
+
+## Benchmark
+
+### [PR-12](https://github.com/zaidsasa/workerpool/pull/12)
+
+```
+➜  workerpool git:(add-benchmark) go test -bench . -benchtime=5s -benchmem
+goos: darwin
+goarch: amd64
+pkg: github.com/zaidsasa/workerpool
+cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
+BenchmarkWorkerPool-8              10000            553632 ns/op           24006 B/op       1000 allocs/op
+PASS
+ok      github.com/zaidsasa/workerpool  7.797s
+```

--- a/workerpool_benchmark_test.go
+++ b/workerpool_benchmark_test.go
@@ -1,0 +1,27 @@
+package workerpool_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zaidsasa/workerpool"
+)
+
+const (
+	poolSize = 10
+	runCount = 1000
+)
+
+func stubFunc() {}
+
+func BenchmarkWorkerPool(b *testing.B) {
+	wPool, _ := workerpool.New(poolSize)
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < runCount; j++ {
+			wPool.Submit(stubFunc)
+		}
+	}
+
+	_ = wPool.Wait(context.Background())
+}


### PR DESCRIPTION
First initial benchmark

```
➜  workerpool git:(add-benchmark) go test -bench . -benchtime=5s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/zaidsasa/workerpool
cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
BenchmarkWorkerPool-8              10000            553632 ns/op           24006 B/op       1000 allocs/op
PASS
ok      github.com/zaidsasa/workerpool  7.797s
```