### PR TITLE
Reduce memory alloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ BenchmarkWorkerPool-8              10000            553632 ns/op           24006
 PASS
 ok      github.com/zaidsasa/workerpool  7.797s
 ```
+
+### [PR-13](https://github.com/zaidsasa/workerpool/pull/13)
+
+```
+➜  workerpool git:(reduce-memory-alloc) go test -bench . -benchtime=5s -benchmem
+goos: darwin
+goarch: amd64
+pkg: github.com/zaidsasa/workerpool
+cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
+BenchmarkWorkerPool-8              27015            209963 ns/op               0 B/op          0 allocs/op
+PASS
+ok      github.com/zaidsasa/workerpool  10.122s
+```

--- a/slot_pool.go
+++ b/slot_pool.go
@@ -1,0 +1,46 @@
+package workerpool
+
+import "sync"
+
+type (
+	slotPool struct {
+		lock     *sync.RWMutex
+		isClosed bool
+		slotChan chan slot
+	}
+
+	slot struct{}
+)
+
+func newSlotPool(size uint32) *slotPool {
+	return &slotPool{
+		lock:     &sync.RWMutex{},
+		slotChan: make(chan slot, size),
+	}
+}
+
+func (sp *slotPool) reserve() bool {
+	sp.lock.RLock()
+	defer sp.lock.RUnlock()
+
+	if sp.isClosed {
+		return false
+	}
+
+	sp.slotChan <- slot{}
+
+	return true
+}
+
+func (sp *slotPool) release() {
+	<-sp.slotChan
+}
+
+func (sp *slotPool) close() {
+	sp.lock.Lock()
+	defer sp.lock.Unlock()
+
+	sp.isClosed = true
+
+	close(sp.slotChan)
+}

--- a/workerpool.go
+++ b/workerpool.go
@@ -96,7 +96,7 @@ func (wp *WorkerPool) finalize() {
 	wp.slots.close()
 }
 
-func worker(slots *slotPool, taskQueue chan Task, waitGroup *sync.WaitGroup) {
+func worker(slots *slotPool, taskQueue <-chan Task, waitGroup *sync.WaitGroup) {
 	for {
 		task, ok := <-taskQueue
 

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -13,7 +13,7 @@ func TestNew(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		size    int
+		size    uint32
 		options []workerpool.Option
 	}
 


### PR DESCRIPTION
1. Reduced memory alloctation.
2. Added workerpool finializer, closes all used channels.

Issues:
execution time is slower this happened after we introduced lock for slotpool.


benchmark:
```
➜  workerpool git:(reduce-memory-alloc) go test -bench . -benchtime=5s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/zaidsasa/workerpool
cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
BenchmarkWorkerPool-8              27015            209963 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/zaidsasa/workerpool  10.122s
```

